### PR TITLE
Update Readme.txt to correct error with update-rc.d

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -103,7 +103,7 @@ cd /etc/init.d
 sudo cp skeleton pimotion.sh
 chmod +x pimotion.sh
 sudo nano pimotion.sh   # change appropriate entries to point to your pimotion.py script
-sudo update-rc.d /etc/init.d/pimotion.sh defaults
+sudo update-rc.d pimotion.sh defaults
 cd ~
 
 


### PR DESCRIPTION
When typing the following:
sudo update-rc.d /etc/init.d/pimotion.sh defaults 
I received the following error:
update-rc.d: using dependency based boot sequencing
update-rc.d: error: unable to read /etc/init.d//etc/init.d/pimotion.sh
Readme amended so that the command reads as follows:
sudo update-rc.d pimotion.sh defaults
